### PR TITLE
Fixes for HTTP/3 CONNECT proxy 

### DIFF
--- a/Network/HTTP3/Control.hs
+++ b/Network/HTTP3/Control.hs
@@ -54,7 +54,7 @@ controlStream conn ref recv = loop0
           else do
             (done, st1) <- readIORef ref >>= parse0 bs
             writeIORef ref st1
-            if done then loop0 else loop
+            if done then loop else loop0
     loop = do
         bs <- recv 1024
         if bs == "" then

--- a/Network/HTTP3/Server.hs
+++ b/Network/HTTP3/Server.hs
@@ -123,14 +123,14 @@ processRequest ctx server strm = E.handleAny reset $ do
     case mvt of
       Nothing -> QUIC.resetStream strm H3MessageError
       Just ht@(_,vt) -> do
-          when (isNothing $ getHeaderValue tokenMethod vt) $ do
-              QUIC.resetStream strm H3MessageError
-          when (isNothing $ getHeaderValue tokenScheme vt) $ do
-              QUIC.resetStream strm H3MessageError
-          when (isNothing $ getHeaderValue tokenAuthority vt) $ do
-              QUIC.resetStream strm H3MessageError
-          when (isNothing $ getHeaderValue tokenPath vt) $ do
-              QUIC.resetStream strm H3MessageError
+          let mMethod    = getHeaderValue tokenMethod vt
+              mScheme    = getHeaderValue tokenScheme vt
+              mAuthority = getHeaderValue tokenAuthority vt
+              mPath      = getHeaderValue tokenPath vt
+          case (mMethod, mScheme, mAuthority, mPath) of
+              (Just "CONNECT", _, Just _, _)   -> return ()
+              (Just _, Just _, Just _, Just _) -> return ()
+              otherwise                        -> QUIC.resetStream strm H3MessageError
           -- fixme: Content-Length
           refI <- newIORef IInit
           refH <- newIORef Nothing


### PR DESCRIPTION
I'm adding HTTP/3 support to [hprox](https://github.com/bjin/hprox), and find that CONNECT proxy is not (yet) supported. After some investigation and tracing, I find two blocking issues. This pull request contains fixes to make CONNECT proxy working with HTTP/3.

The client I'm using to test is the builtin QUIC Proxy implementation in Chrome 112 (it supports `h3` protocol).

~There is still a minor issue that `conduit` pipes in my implementation is not closed even both client and server closed streams (the same is not happening with HTTP/2), I will try to figure it out why, and possibly open another pull request.~

EDIT: opened PR kazu-yamamoto/quic#54